### PR TITLE
Reverted one terminated ord paths

### DIFF
--- a/benches/ordpath.rs
+++ b/benches/ordpath.rs
@@ -1,17 +1,11 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ordpath::{
-    enc::{self, Encoding},
-    OneTerminatedPath, OrdPath, ZeroTerminatedPath,
-};
+use ordpath::{enc, OrdPath};
 
-fn comparison<E: Encoding, const N: usize, const T: bool, F: Fn(&[i64]) -> OrdPath<E, N, T>>(
-    c: &mut Criterion,
-    f: F,
-) {
+fn comparison(c: &mut Criterion) {
     for len in &[0, 10, 50, 100, 500, 1000] {
         let seq = (0..*len).collect::<Vec<_>>();
-        let x = f(&seq);
-        let y = f(&seq);
+        let x = <OrdPath>::from_slice(&seq, enc::Default);
+        let y = <OrdPath>::from_slice(&seq, enc::Default);
 
         c.bench_function(&format!("ordpath_comparison_{}", len), |b| {
             b.iter(|| {
@@ -21,41 +15,19 @@ fn comparison<E: Encoding, const N: usize, const T: bool, F: Fn(&[i64]) -> OrdPa
     }
 }
 
-fn comparison_zero_term(c: &mut Criterion) {
-    comparison(c, |s| <ZeroTerminatedPath>::from_slice(s, enc::Default));
-}
-
-fn comparison_one_term(c: &mut Criterion) {
-    comparison(c, |s| <OneTerminatedPath>::from_slice(s, enc::Default));
-}
-
-fn from_slice<E: Encoding, const N: usize, const T: bool, F: Fn(&[i64]) -> OrdPath<E, N, T>>(
-    c: &mut Criterion,
-    f: F,
-) {
+fn from_slice(c: &mut Criterion) {
     for len in &[0, 10, 50, 100, 500, 1000] {
         let s = (0..*len).collect::<Vec<_>>();
 
         c.bench_function(&format!("ordpath_from_slice_{}", len), |b| {
             b.iter(|| {
-                black_box(f(&s));
+                black_box(<OrdPath>::from_slice(&s, enc::Default));
             })
         });
     }
 }
 
-fn from_slice_one_term(c: &mut Criterion) {
-    from_slice(c, |s| <ZeroTerminatedPath>::from_slice(s, enc::Default));
-}
-
-fn from_slice_zero_term(c: &mut Criterion) {
-    from_slice(c, |s| <ZeroTerminatedPath>::from_slice(s, enc::Default));
-}
-
-fn from_str<E: Encoding, const N: usize, const T: bool, F: Fn(&str) -> OrdPath<E, N, T>>(
-    c: &mut Criterion,
-    f: F,
-) {
+fn from_str(c: &mut Criterion) {
     for len in &[0, 10, 50, 100, 500, 1000] {
         let s = (0..*len)
             .map(|x| x.to_string())
@@ -64,28 +36,17 @@ fn from_str<E: Encoding, const N: usize, const T: bool, F: Fn(&str) -> OrdPath<E
 
         c.bench_function(&format!("ordpath_from_str_{}", len), |b| {
             b.iter(|| {
-                black_box(f(&s));
+                black_box(<OrdPath>::from_str(&s, enc::Default));
             })
         });
     }
 }
 
-fn from_str_one_term(c: &mut Criterion) {
-    from_str(c, |s| <ZeroTerminatedPath>::from_str(s, enc::Default));
-}
-
-fn from_str_zero_term(c: &mut Criterion) {
-    from_str(c, |s| <ZeroTerminatedPath>::from_str(s, enc::Default));
-}
-
-fn is_ancestor_of<E: Encoding, const N: usize, const T: bool, F: Fn(&[i64]) -> OrdPath<E, N, T>>(
-    c: &mut Criterion,
-    f: F,
-) {
+fn is_ancestor_of(c: &mut Criterion) {
     for len in &[0, 10, 50, 100, 500, 1000] {
         let seq = (0..*len).collect::<Vec<_>>();
-        let x = f(&seq);
-        let y = f(&seq);
+        let x = <OrdPath>::from_slice(&seq, enc::Default);
+        let y = <OrdPath>::from_slice(&seq, enc::Default);
 
         c.bench_function(&format!("ordpath_is_ancestor_of_{}", len), |b| {
             b.iter(|| {
@@ -95,21 +56,10 @@ fn is_ancestor_of<E: Encoding, const N: usize, const T: bool, F: Fn(&[i64]) -> O
     }
 }
 
-fn is_ancestor_of_one_term(c: &mut Criterion) {
-    is_ancestor_of(c, |s| <ZeroTerminatedPath>::from_slice(s, enc::Default));
-}
-
-fn is_ancestor_of_zero_term(c: &mut Criterion) {
-    is_ancestor_of(c, |s| <ZeroTerminatedPath>::from_slice(s, enc::Default));
-}
-
-fn iteration<E: Encoding, const N: usize, const T: bool, F: Fn(&[i64]) -> OrdPath<E, N, T>>(
-    c: &mut Criterion,
-    f: F,
-) {
+fn iteration(c: &mut Criterion) {
     for len in &[0, 10, 50, 100, 500, 1000] {
         let s = (0..*len).collect::<Vec<_>>();
-        let p = f(&s);
+        let p = <OrdPath>::from_slice(&s, enc::Default);
 
         c.bench_function(&format!("ordpath_iteration{}", len), |b| {
             b.iter(|| {
@@ -121,26 +71,13 @@ fn iteration<E: Encoding, const N: usize, const T: bool, F: Fn(&[i64]) -> OrdPat
     }
 }
 
-fn iteration_one_term(c: &mut Criterion) {
-    iteration(c, |s| <ZeroTerminatedPath>::from_slice(s, enc::Default));
-}
-
-fn iteration_zero_term(c: &mut Criterion) {
-    iteration(c, |s| <ZeroTerminatedPath>::from_slice(s, enc::Default));
-}
-
 criterion_group!(
     benches,
-    comparison_one_term,
-    comparison_zero_term,
-    from_slice_one_term,
-    from_slice_zero_term,
-    from_str_one_term,
-    from_str_zero_term,
-    is_ancestor_of_one_term,
-    is_ancestor_of_zero_term,
-    iteration_one_term,
-    iteration_zero_term,
+    comparison,
+    from_slice,
+    from_str,
+    is_ancestor_of,
+    iteration,
 );
 
 criterion_main!(benches);


### PR DESCRIPTION
The option of specifying wherever a bit string terminates with an additional set bit isn't used by any know implementation of ORDPATH while it can be quite useful for determining the string length in bits. The version used by SQL Server seems to use that trick, but it actually has a more complicated solution where only odd ending string has it while caret-in labels don't.

Therefore, after removal of this feature there should be an attempt to build a more advanced solution which can handle that implementation which SQL Server uses. Perhaps, it's ORDPATH DLN, but that needs to be investigated.